### PR TITLE
Update examples to initialize sys_clk/uart_clk using clock::Strict

### DIFF
--- a/examples/bl602-gpio-blinky.rs
+++ b/examples/bl602-gpio-blinky.rs
@@ -1,14 +1,18 @@
 #![no_std]
 #![no_main]
 
-use bl602_hal::{pac, prelude::*};
+use bl602_hal::{clock::*, pac, prelude::*};
 
 use panic_halt as _;
 
 #[riscv_rt::entry]
 fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
-    let parts = dp.GLB.split();
+    let mut parts = dp.GLB.split();
+    let clocks = Strict::new()
+        .use_pll(40_000_000u32.Hz())
+        .sys_clk(SysclkFreq::Pll160Mhz)
+        .freeze(&mut parts.clk_cfg);
     let mut gpio5 = parts.pin5.into_pull_down_output();
     gpio5.try_set_high().unwrap();
     loop {

--- a/examples/bl602-gpio-blinky.rs
+++ b/examples/bl602-gpio-blinky.rs
@@ -13,7 +13,7 @@ use hal::{
 fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
     let mut parts = dp.GLB.split();
-    let clocks = clock::Strict::new()
+    let _clocks = clock::Strict::new()
         .use_pll(40_000_000u32.Hz())
         .sys_clk(SysclkFreq::Pll160Mhz)
         .freeze(&mut parts.clk_cfg);

--- a/examples/bl602-gpio-blinky.rs
+++ b/examples/bl602-gpio-blinky.rs
@@ -1,15 +1,19 @@
 #![no_std]
 #![no_main]
 
-use bl602_hal::{clock::*, pac, prelude::*};
-
 use panic_halt as _;
+use bl602_hal as hal;
+use hal::{
+    clock::{self, SysclkFreq},
+    pac,
+    prelude::*,
+};
 
 #[riscv_rt::entry]
 fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
     let mut parts = dp.GLB.split();
-    let clocks = Strict::new()
+    let clocks = clock::Strict::new()
         .use_pll(40_000_000u32.Hz())
         .sys_clk(SysclkFreq::Pll160Mhz)
         .freeze(&mut parts.clk_cfg);

--- a/examples/bl602-serial.rs
+++ b/examples/bl602-serial.rs
@@ -13,7 +13,7 @@ use hal::{
 fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
     let mut parts = dp.GLB.split();
-    let clocks = clock::Strict::new()
+    let _clocks = clock::Strict::new()
         .use_pll(40_000_000u32.Hz())
         .sys_clk(SysclkFreq::Pll160Mhz)
         .uart_clk(UART_PLL_FREQ.Hz())
@@ -49,10 +49,10 @@ fn main() -> ! {
         .cr_urx_rts_sw_mode().clear_bit() // no RTS
         .cr_urx_en().set_bit() // enable RX
     });
-    let pin16 = parts.pin16.into_uart_sig0();
-    let pin7 = parts.pin7.into_uart_sig7();
-    let mux0 = parts.uart_mux0.into_uart0_tx();
-    let mux7 = parts.uart_mux7.into_uart0_rx();
+    let _pin16 = parts.pin16.into_uart_sig0();
+    let _pin7 = parts.pin7.into_uart_sig7();
+    let _mux0 = parts.uart_mux0.into_uart0_tx();
+    let _mux7 = parts.uart_mux7.into_uart0_rx();
     loop {
         // write data
         while dp.UART.uart_fifo_config_1.read().tx_fifo_cnt().bits() < 1 {}

--- a/examples/bl602-serial.rs
+++ b/examples/bl602-serial.rs
@@ -1,15 +1,19 @@
 #![no_std]
 #![no_main]
 
-use bl602_hal::{pac, clock::*, prelude::*};
-
 use panic_halt as _;
+use bl602_hal as hal;
+use hal::{
+    clock::{self, SysclkFreq, UART_PLL_FREQ},
+    pac,
+    prelude::*,
+};
 
 #[riscv_rt::entry]
 fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
     let mut parts = dp.GLB.split();
-    let clocks = bl602_hal::clock::Strict::new()
+    let clocks = clock::Strict::new()
         .use_pll(40_000_000u32.Hz())
         .sys_clk(SysclkFreq::Pll160Mhz)
         .uart_clk(UART_PLL_FREQ.Hz())

--- a/examples/bl602-serial.rs
+++ b/examples/bl602-serial.rs
@@ -1,20 +1,19 @@
 #![no_std]
 #![no_main]
 
-use bl602_hal::pac;
+use bl602_hal::{pac, clock::*, prelude::*};
 
 use panic_halt as _;
 
 #[riscv_rt::entry]
 fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
-    // enable clock
-    // let clock = 160_000_000 as u32;
-    let uart_clk_div = 3; // reset
-    dp.GLB.clk_cfg2.write(|w| unsafe { w
-        .uart_clk_div().bits(uart_clk_div)
-        .uart_clk_en().set_bit()
-    });
+    let mut parts = dp.GLB.split();
+    let clocks = bl602_hal::clock::Strict::new()
+        .use_pll(40_000_000u32.Hz())
+        .sys_clk(SysclkFreq::Pll160Mhz)
+        .uart_clk(UART_PLL_FREQ.Hz())
+        .freeze(&mut parts.clk_cfg);
     // calculate baudrate
     let baudrate_divisor = 2000;  // 160M / 4 / 2000 = 20K baud
     dp.UART.uart_bit_prd.write(|w| unsafe { w
@@ -46,29 +45,10 @@ fn main() -> ! {
         .cr_urx_rts_sw_mode().clear_bit() // no RTS
         .cr_urx_en().set_bit() // enable RX
     });
-    // set gpio configuration
-    // tx pin
-    dp.GLB.gpio_cfgctl8.modify(|_, w| unsafe { w
-        .reg_gpio_16_func_sel().bits(7) // GPIO_FUN_UART
-        .reg_gpio_16_ie().set_bit() // input
-        .reg_gpio_16_pu().set_bit() // pull up enable
-        .reg_gpio_16_pd().clear_bit()
-        .reg_gpio_16_drv().bits(0) // disabled
-        .reg_gpio_16_smt().clear_bit()
-    });
-    // rx pin
-    dp.GLB.gpio_cfgctl3.modify(|_, w| unsafe { w
-        .reg_gpio_7_func_sel().bits(7) // GPIO_FUN_UART
-        .reg_gpio_7_ie().set_bit() // input
-        .reg_gpio_7_pu().set_bit() // pull up enable
-        .reg_gpio_7_pd().clear_bit()
-        .reg_gpio_7_drv().bits(0) // disabled
-        .reg_gpio_7_smt().clear_bit()
-    });
-    dp.GLB.uart_sig_sel_0.write(|w| unsafe { w
-        .uart_sig_0_sel().bits(2) // tx -> GLB_UART_SIG_FUN_UART0_TXD
-        .uart_sig_7_sel().bits(3) // rx -> GLB_UART_SIG_FUN_UART0_RXD
-    });
+    let pin16 = parts.pin16.into_uart_sig0();
+    let pin7 = parts.pin7.into_uart_sig7();
+    let mux0 = parts.uart_mux0.into_uart0_tx();
+    let mux7 = parts.uart_mux7.into_uart0_rx();
     loop {
         // write data
         while dp.UART.uart_fifo_config_1.read().tx_fifo_cnt().bits() < 1 {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use bl602_hal::{serial::*, pac, prelude::*, clock::Strict};
+use bl602_hal::{clock::*, pac, prelude::*, serial::*};
 
 use panic_halt as _;
 
@@ -11,6 +11,9 @@ fn main() -> ! {
     let mut parts = dp.GLB.split();
     // enable clock
     let clocks = Strict::new()
+        .use_pll(40_000_000u32.Hz())
+        .sys_clk(SysclkFreq::Pll160Mhz)
+        .uart_clk(UART_PLL_FREQ.Hz())
         .freeze(&mut parts.clk_cfg);
     let pin16 = parts.pin16.into_uart_sig0();
     let pin7 = parts.pin7.into_uart_sig7();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,21 @@
 #![no_std]
 #![no_main]
 
-use bl602_hal::{clock::*, pac, prelude::*, serial::*};
-
 use panic_halt as _;
+use bl602_hal as hal;
+use hal::{
+    clock::{self, SysclkFreq, UART_PLL_FREQ},
+    serial::{Serial, Config},
+    pac,
+    prelude::*,
+};
 
 #[riscv_rt::entry]
 fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
     let mut parts = dp.GLB.split();
     // enable clock
-    let clocks = Strict::new()
+    let clocks = clock::Strict::new()
         .use_pll(40_000_000u32.Hz())
         .sys_clk(SysclkFreq::Pll160Mhz)
         .uart_clk(UART_PLL_FREQ.Hz())


### PR DESCRIPTION
This is bringing in the minimum amount of changes require for main and examples to work with the new clock code in the HAL.
The UART example needed a few more modifications than the others, since it was using GLB registers to configure UART clk_en and clk_div